### PR TITLE
OVDX-7000: Add request Id to delayed_job logging

### DIFF
--- a/lib/delayed/backend/job_preparer.rb
+++ b/lib/delayed/backend/job_preparer.rb
@@ -9,6 +9,7 @@ module Delayed
       end
 
       def prepare
+        attach_request_id
         set_payload
         set_queue_name
         set_priority
@@ -17,6 +18,10 @@ module Delayed
       end
 
     private
+
+      def attach_request_id
+        options[:distributed_request_id] = options[:distributed_request_id] || Thread.current[:x_request_id]
+      end
 
       def set_payload
         options[:payload_object] ||= args.shift

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -15,6 +15,7 @@ module Delayed
         attr_accessor :locked_by
         attr_accessor :failed_at
         attr_accessor :queue
+        attr_accessor :distributed_request_id
 
         include Delayed::Backend::Base
 


### PR DESCRIPTION
Updated the DJ version we're pointed at to add the DRID to the job record when it's instantiated.